### PR TITLE
Adds responsiveness to the navigation and body for tablet sizes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -143,6 +143,11 @@ img {
     font-weight: var(--font-semi);
 }
 
+.nav__menu {
+    position: absolute;
+    right: 11rem;
+}
+
 @media screen and (max-width: 768px) {
     .nav__menu {
         position: fixed;
@@ -546,7 +551,7 @@ img {
     }
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 768px) {
     .bd-grid {
         margin-left: auto;
         margin-right: auto;


### PR DESCRIPTION
## 🧰 Issue
Closes #6 

## 🚀 Overview: 
Adds a responsive breakpoint for tablets

## 🤔 Reason: 
The layout breaks in between desktop and phone sizes.

## 🔨Work carried out:

- [x] Added an extra media query for the top navigation
- [x] Updated the `.bd-grid` MQ to trigger at a smaller resolution

## 🖥️ Screenshot

![2020-10-06 16 22 25](https://user-images.githubusercontent.com/151028/95222304-440a4000-07f0-11eb-8ec0-4762ea7b0616.gif)

## 📝 Developer Notes:
- I wasn't 100% clear on your requirement and as it's not my design, I just fixed the parts that broke rather than changing
 the design to accommodate different sizes.

